### PR TITLE
Add support for ECH extension in TLS 1.3 handshake

### DIFF
--- a/src/java.base/share/classes/javax/net/ssl/SSLParameters.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLParameters.java
@@ -86,6 +86,9 @@ public class SSLParameters {
     private String[] applicationProtocols = new String[0];
     private String[] signatureSchemes = null;
 
+    String innerSNI;
+    String echConfig;
+
     /**
      * Constructs SSLParameters.
      * <p>
@@ -810,4 +813,41 @@ public class SSLParameters {
 
         this.signatureSchemes = tempSchemes;
     }
+
+    /**
+     * return the inner SNI, if available
+     *
+     * @return inner SNI
+     */
+    public String getInnerSNI() {
+        return this.innerSNI;
+    }
+
+    /**
+     * Set the inner SNI
+     *
+     * @param is the inner SNI
+     */
+    public void setInnerSNI(String is) {
+        this.innerSNI = is;
+    }
+
+    /**
+     * get the ECHConfig
+     *
+     * @return the echConfig
+     */
+    public String getEchConfig() {
+        return echConfig;
+    }
+
+    /**
+     * set the ech config
+     *
+     * @param echConfig the echConfig
+     */
+    public void setEchConfig(String echConfig) {
+        this.echConfig = echConfig;
+    }
+
 }

--- a/src/java.base/share/classes/sun/security/ssl/ClientHandshakeContext.java
+++ b/src/java.base/share/classes/sun/security/ssl/ClientHandshakeContext.java
@@ -97,6 +97,8 @@ class ClientHandshakeContext extends HandshakeContext {
 
     // PSK identity is selected in first Hello and used again after HRR
     byte[] pskIdentity;
+    ClientHelloMessage innerClientHelloMessage; // needed when we swap outer/inner
+    String innerSNI;
 
     ClientHandshakeContext(SSLContextImpl sslContext,
             TransportContext conContext) throws IOException {

--- a/src/java.base/share/classes/sun/security/ssl/ClientHello.java
+++ b/src/java.base/share/classes/sun/security/ssl/ClientHello.java
@@ -27,14 +27,19 @@ package sun.security.ssl;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.security.KeyPair;
+import java.security.PublicKey;
 import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
 import java.text.MessageFormat;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HexFormat;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLPeerUnverifiedException;
@@ -47,8 +52,11 @@ import sun.security.ssl.SupportedVersionsExtension.CHSupportedVersionsSpec;
  * Pack of the ClientHello handshake message.
  */
 final class ClientHello {
-    static final SSLProducer kickstartProducer =
-        new ClientHelloKickstartProducer();
+
+    static final int OSSL_ECH_PADDING_TARGET = 256;
+    static final int OSSL_ECH_PADDING_INCREMENT = 32;
+    static final SSLProducer kickstartProducer
+            = new ClientHelloKickstartProducer();
     static final SSLConsumer handshakeConsumer =
         new ClientHelloConsumer();
     static final HandshakeProducer handshakeProducer =
@@ -79,13 +87,23 @@ final class ClientHello {
         final List<CipherSuite>     cipherSuites;   // known cipher suites only
         final byte[]                compressionMethod;
         final SSLExtensions         extensions;
+        boolean inner;
 
         private static final byte[]  NULL_COMPRESSION = new byte[] {0};
 
+        public Map<SSLExtension, byte[]> getExtensions() {
+            return extensions.getExtMap();
+        }
+
+        void setExtensions(Map<SSLExtension, byte[]> m) {
+            this.extensions.setExtMap(m);
+        }
+
         ClientHelloMessage(HandshakeContext handshakeContext,
                 int clientVersion, SessionId sessionId,
-                List<CipherSuite> cipherSuites, SecureRandom generator) {
+                List<CipherSuite> cipherSuites, SecureRandom generator, boolean inner) {
             super(handshakeContext);
+            this.inner = inner;
             this.isDTLS = handshakeContext.sslContext.isDTLS();
 
             this.clientVersion = clientVersion;
@@ -99,7 +117,7 @@ final class ClientHello {
 
             this.cipherSuites = cipherSuites;
             this.cipherSuiteIds = getCipherSuiteIds(cipherSuites);
-            this.extensions = new SSLExtensions(this);
+            this.extensions = new SSLExtensions(this, inner);
 
             // Don't support compression.
             this.compressionMethod = NULL_COMPRESSION;
@@ -329,6 +347,30 @@ final class ClientHello {
             hos.putBytes8(compressionMethod);
         }
 
+        public byte[] toByteArray() throws IOException {
+            byte[] hb = getHeaderBytes();
+            HandshakeOutStream hos = new HandshakeOutStream(null);
+            this.extensions.send(hos);
+            byte[] eb = hos.toByteArray();
+            byte[] answer = new byte[hb.length + eb.length];
+            System.arraycopy(hb, 0, answer, 0, hb.length);
+            System.arraycopy(eb, 0, answer, hb.length, eb.length);
+            return answer;
+        }
+
+        public byte[] getEncodedByteArray() throws IOException {
+            HandshakeOutStream hos = new HandshakeOutStream(null);
+            hos.putInt8((byte) ((clientVersion >>> 8) & 0xFF));
+            hos.putInt8((byte) (clientVersion & 0xFF));
+            hos.write(clientRandom.randomBytes, 0, 32);
+            hos.putInt8(0); // empty session id
+            hos.putBytes16(getEncodedCipherSuites());
+            hos.putBytes8(compressionMethod);
+            this.extensions.send(hos);
+            return hos.toByteArray();
+        }
+
+
         @Override
         public String toString() {
             if (isDTLS) {
@@ -388,6 +430,10 @@ final class ClientHello {
      */
     private static final
             class ClientHelloKickstartProducer implements SSLProducer {
+
+        private ECHConfig echConfig;
+        private HPKEContext hpkeContext;
+
         // Prevent instantiation of this class.
         private ClientHelloKickstartProducer() {
             // blank
@@ -398,7 +444,22 @@ final class ClientHello {
         public byte[] produce(ConnectionContext context) throws IOException {
             // The producing happens in client side only.
             ClientHandshakeContext chc = (ClientHandshakeContext)context;
-
+            String innerCh = chc.sslConfig.innerSNI;
+            // we first test on innerCh presence.
+            // in following tests, echConfig is the source of truth
+            if (innerCh != null) {
+                SSLLogger.info("produce CH with innerCH with SNU "+innerCh);
+                String echString = chc.sslConfig.echConfig;
+                this.echConfig = new ECHConfig(HexFormat.of().parseHex(echString));
+                PublicKey peerPub = HPKEContext.convertEncodedPublicKey(echConfig.getPublicKey());
+                KeyPair ephemeral = HPKEContext.deriveKeyPair(null);
+                this.hpkeContext = new HPKEContext(peerPub, ephemeral, this.echConfig.createInfo());
+                hpkeContext.create();
+                chc.hpkeContext = hpkeContext;
+                chc.innerSNI = innerCh;
+            } else {
+                this.echConfig = null;
+            }
             // clean up this producer
             chc.handshakeProducers.remove(SSLHandshake.CLIENT_HELLO.id);
 
@@ -406,8 +467,10 @@ final class ClientHello {
             SessionId sessionId = new SessionId(new byte[0]);
 
             // a list of cipher suites sent by the client
-            List<CipherSuite> cipherSuites = chc.activeCipherSuites;
-
+            List<CipherSuite> ccipherSuites = chc.activeCipherSuites;
+            List<CipherSuite> cipherSuites = new ArrayList<>();
+            cipherSuites.addAll(ccipherSuites);
+            cipherSuites.add(CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV);
             //
             // Try to resume an existing session.
             //
@@ -416,6 +479,9 @@ final class ClientHello {
             SSLSessionImpl session = ssci.get(
                     chc.conContext.transport.getPeerHost(),
                     chc.conContext.transport.getPeerPort());
+            if (this.echConfig != null) {
+                session = null;
+            }
             if (session != null) {
                 // If unsafe server certificate change is not allowed, reserve
                 // current server certificates if the previous handshake is a
@@ -626,8 +692,8 @@ final class ClientHello {
 
             ClientHelloMessage chm = new ClientHelloMessage(chc,
                     clientHelloVersion.id, sessionId, cipherSuites,
-                    chc.sslContext.getSecureRandom());
-
+                    chc.sslContext.getSecureRandom(), false);
+            chc.initialClientHelloMsg = chm;
             // cache the client random number for further using
             chc.clientHelloRandom = chm.clientRandom;
             chc.clientHelloVersion = clientHelloVersion.id;
@@ -635,10 +701,68 @@ final class ClientHello {
             // Produce extensions for ClientHello handshake message.
             SSLExtension[] extTypes = chc.sslConfig.getEnabledExtensions(
                     SSLHandshake.CLIENT_HELLO, chc.activeProtocols);
+            SSLLogger.info("This CH will be processed with echconfig "+echConfig);
+            chc.setEchConfig(echConfig);
             chm.extensions.produce(chc, extTypes);
 
             if (SSLLogger.isOn && SSLLogger.isOn("ssl,handshake")) {
                 SSLLogger.fine("Produced ClientHello handshake message", chm);
+            }
+
+// ========= inner ECH
+            if (this.echConfig != null) {
+                ClientHelloMessage innerChm = new ClientHelloMessage(chc,
+                        chc.clientHelloVersion, chm.sessionId, chm.cipherSuites,
+                        chc.sslContext.getSecureRandom(), true);
+                chc.setInnerEch(true);
+                chc.innerClientHelloMessage = innerChm;
+                chc.innerClientHelloRandom = innerChm.clientRandom;
+                innerChm.extensions.produce(chc, extTypes);
+
+                chc.setInnerEch(false);
+                byte[] innerCH = innerChm.toByteArray();
+                SSLLogger.info("inner CH", innerCH);
+                byte[] clear = innerChm.getEncodedByteArray();
+                SSLLogger.info("Before padding, clear (" + clear.length + ") = ", clear);
+                int clearLen = calculateClearLength(clear.length, echConfig.getMaxNameLength());
+                byte[] newclear = new byte[clearLen];
+                System.arraycopy(clear, 0, newclear, 0, clear.length);
+                clear = newclear;
+                SSLLogger.info("After padding, clear (" + clear.length + ") = ", clear);
+
+                byte[] pkt = chm.toByteArray();
+                SSLLogger.info("orignal packets (pkt)", pkt);
+                int cipherlen = clearLen + 16; // not valid for all AEAD
+                int echStart = pkt.length - 40;
+                pkt = expandOuterCH(pkt, (byte) this.echConfig.getConfigId(), hpkeContext.getEphemeralPublicKeyBytes(), cipherlen);
+                int echLength = pkt.length - echStart;
+                SSLLogger.info("after expanding, pkt (" + pkt.length + ")", pkt);
+                byte[] aad = new byte[pkt.length];
+
+// set tmp extension so that we get correct size of extensions
+                byte[] tmpCH = new byte[pkt.length - echStart];
+                System.arraycopy(pkt, echStart, tmpCH, 0, tmpCH.length);
+
+                chm.extensions.updateExtension(SSLExtension.CH_ECH, tmpCH);
+                pkt = chm.toByteArray();
+
+                System.arraycopy(pkt, 0, aad, 0, aad.length);
+                // pkt and aad now have correct extensions size and are equal
+                // add first
+                SSLLogger.info("Before cipher calc, aad = (" + aad.length + ")", aad);
+                SSLLogger.info("Before cipher calc, clear = (" + clear.length + ")", clear);
+                byte[] cipher = hpkeContext.seal(aad, clear);
+
+                // now modify pkt (clientouter) so that it has the cipher instead of zeroes
+                // we do this by changing the ech extension and ask to recalculate (which is done when asking updateExtension and toByteArray)
+                byte[] newCH = new byte[echLength];
+                System.arraycopy(tmpCH, 0, newCH, 0, echLength);
+                System.arraycopy(cipher, 0, newCH, echLength - cipherlen, cipherlen);
+                chm.extensions.updateExtension(SSLExtension.CH_ECH, newCH);
+                chc.innerClientHello = innerChm.toByteArray();
+                SSLLogger.info("ClientHelloOuter = ", chm.toByteArray());
+
+                // ===========
             }
 
             // Output the handshake message.
@@ -661,6 +785,40 @@ final class ClientHello {
 
             // The handshake message has been delivered.
             return null;
+        }
+
+        private int calculateClearLength(int il, int mnl) {
+            if (mnl > 0) {
+                System.err.println("WARNING, ECHCONFIG DEFINED MAXNAMELENGTH! not supported!");
+            }
+            int innersnipadding = 0;
+            int lengthWithSniPadding = innersnipadding + il;
+            int lengthOfPadding = 31 - ((lengthWithSniPadding - 1) % 32);
+            int lengthWithPadding = il + lengthOfPadding + innersnipadding;
+            while (lengthWithPadding < OSSL_ECH_PADDING_TARGET) {
+                lengthWithPadding += OSSL_ECH_PADDING_INCREMENT;
+            }
+            int clearLen = lengthWithPadding;
+            SSLLogger.info("EAAE: Padding: mnl " + echConfig.getMaxNameLength() + ", lws: " + lengthWithSniPadding
+                    + ",lop: " + lengthOfPadding + ", lwp: " + lengthWithPadding
+                    + ", clear_len: " + clearLen + ", orig: " + il);
+
+            return clearLen;
+        }
+
+        private byte[] expandOuterCH(byte[] src, byte cfgid, byte[] mypub, int cipherlen) {
+            byte[] answer = new byte[src.length + 2 + cipherlen];
+            System.arraycopy(src, 0, answer, 0, src.length);
+            int ef0dlength = 1 + 4 + 1 + 2 + mypub.length + 2 + cipherlen;
+            int lengthloc = src.length - 42;
+            answer[lengthloc] = (byte) (ef0dlength / 256);
+            answer[lengthloc + 1] = (byte) (ef0dlength % 256);
+            int cipherloc = src.length;
+            answer[cipherloc] = (byte) (cipherlen / 256);
+            answer[cipherloc + 1] = (byte) (cipherlen % 256);
+            SSLLogger.info("expanded outer ch into size " + answer.length);
+
+            return answer;
         }
     }
 

--- a/src/java.base/share/classes/sun/security/ssl/ECHConfig.java
+++ b/src/java.base/share/classes/sun/security/ssl/ECHConfig.java
@@ -1,0 +1,244 @@
+package sun.security.ssl;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+
+/**
+ * EchConfig class
+ * @author johan
+ */
+public class ECHConfig {
+    
+    static int DEFAULT_VERSION = 0xfe0d;
+    static int CIPHER_LENGTH = 4;
+    
+    byte[] raw; // the original raw binary data. Everything else can be parsed from this.
+
+    int rawLength; // including version etc
+    int version;
+    int length; // net length
+    int configId;
+    int kemId;
+    byte[] publicKey;
+    int[] cipher;
+    HpkeSuite[] cipherSuite;
+    HpkeSuite selectedSuite;
+    String publicName;
+    int maxNameLength;
+
+    /**
+     * Create ECH
+     */
+    public ECHConfig() {        
+    }
+    
+    /**
+     * constructor
+     * @param binbuf raw data 
+     */
+    public ECHConfig(byte[] binbuf) {
+        parse(binbuf);
+    }
+    
+    /**
+     * get raw data
+     * @return raw data
+     */
+    public byte[] getRaw() {
+        return this.raw;
+    }
+
+    /**
+     * get max filename length
+     * @return max
+     */
+    public int getMaxNameLength() {
+        return this.maxNameLength;
+    }
+
+    /**
+     * Get kem
+     * @return kem 
+     */
+    public int getKemId() {
+        return this.kemId;
+    }
+
+    /**
+     * set version
+     * @param v new version
+     */
+    public void setVersion(int v) {
+        this.version = v;
+    }
+    
+    /**
+     * get version
+     * @return the version
+     */
+    public int getVersion() {
+        return this.version;
+    }
+
+    /**
+     * set config id
+     * @param b the id
+     */
+    public void setConfigId(byte b) {
+        this.configId = b;
+    }
+    
+    /**
+     * get config id
+     * @return the id
+     */
+    public int getConfigId() {
+        return this.configId;
+    }
+    
+    /**
+     * get pk
+     * @return the PK 
+     */
+    public byte[] getPublicKey() {
+        return this.publicKey;
+    }
+
+    /**
+     * Return the name we can use in the outer ClientHello.
+     *
+     * @return the public name
+     */
+    public String getPublicName() {
+        return this.publicName;
+    }
+
+    private void parse(byte[] binbuf) {
+        int ptr = 0;
+        this.rawLength = readBytes(binbuf,ptr,2);
+        SSLLogger.info("parse ECHConfig, full length = "+binbuf.length+" and raw = "+rawLength);
+        ptr += 2;
+        this.raw = new byte[rawLength];
+        System.arraycopy(binbuf, 2, raw, 0, rawLength);
+        this.version = readBytes(binbuf, ptr, 2);
+        ptr += 2;
+        this.length = readBytes(binbuf, ptr, 2);
+        ptr += 2;
+        this.configId = readBytes(binbuf, ptr, 1);
+        ptr++;
+        this.kemId = readBytes(binbuf, ptr, 2);
+        ptr += 2;
+        int publen = readBytes(binbuf, ptr, 2);
+        ptr += 2;
+        this.publicKey = new byte[publen];
+        System.arraycopy(binbuf, ptr, this.publicKey, 0, publen);
+        ptr +=publen;
+        int cl = readBytes(binbuf, ptr, 2);
+        ptr += 2;
+        int suiteCount = cl/CIPHER_LENGTH;
+        cipher = new int[suiteCount];
+        cipherSuite = new HpkeSuite[suiteCount];
+        for (int i = 0; i < suiteCount; i++) {
+            int val = readBytes(binbuf, ptr, 4);
+            cipher[i] = val;
+            HpkeSuite hs = new HpkeSuite(val/(1<<16), val%(1<<16) );
+            cipherSuite[i] = hs;
+            ptr += 4;
+        }
+        this.selectedSuite = cipherSuite[0];
+        this.maxNameLength = readBytes(binbuf, ptr, 1);
+        ptr++;
+        int pubnamelen = readBytes(binbuf, ptr, 1);
+        ptr++;
+        byte[] pubname = new byte[pubnamelen];
+        System.arraycopy(binbuf, ptr, pubname, 0, pubnamelen);
+        this.publicName = new String(pubname);
+        SSLLogger.info("pubname = "+publicName);
+    }
+    
+    int readBytes(byte[] src, int offset, int len) {
+        int res = 0;
+        for (int i = 0; i < len;i++) {
+            res = res * 256 + (256+src[offset+i])%256;
+        }
+        return res;
+    }
+    
+    /**
+     * Create the bytes required for the encrypted_client_hello Extension
+     * @return the bytes that need to be used in the extension. In case of 
+     * an outer extension, the ephemeral public key (client generated) and
+     * the payload need to be added separately (in EchExtension)
+     * See https://datatracker.ietf.org/doc/draft-ietf-tls-esni/ section 5
+     */
+//     enum { outer(0), inner(1) } ECHClientHelloType;
+//
+//       struct {
+//          ECHClientHelloType type;
+//          select (ECHClientHello.type) {
+//              case outer:
+//                  HpkeSymmetricCipherSuite cipher_suite;
+//                  uint8 config_id;
+//                  opaque enc<0..2^16-1>;
+//                  opaque payload<1..2^16-1>;
+//              case inner:
+//                  Empty;
+//          };
+//       } ECHClientHello;
+   
+    byte [] produceExtension(boolean inner) throws IOException {
+        if (inner) {
+            return new byte[]{0x1}; // code for inner = 0x1, rest is empty
+        } else {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            baos.write(0x0);
+            baos.write(selectedSuite.toSerial());
+            baos.write(this.configId);
+            byte[] answer = baos.toByteArray();
+            return answer;
+        }
+    }
+    static final String OSSL_ECH_CONTEXT_STRING = "tls ech";
+
+    /**
+     * Create the info component required to create the HPKE context
+     * @return 
+     */
+    public byte[] createInfo() {
+        byte[] oecb = OSSL_ECH_CONTEXT_STRING.getBytes();
+        byte[] info = new byte[oecb.length + 1 + getRaw().length];
+        System.arraycopy(oecb, 0, info, 0, oecb.length);
+        info[oecb.length] = 0;
+        System.arraycopy(getRaw(), 0, info, oecb.length + 1, getRaw().length);
+        return info;
+    }
+
+    @Override public String toString() {
+        String v =  Integer.toHexString(version);
+        return "ECHConfig version "+v
+                + "\nInner length = "+length
+                + "\nconfig_id = "+configId+" ("+Integer.toHexString(configId)+")"
+                + "\npubname = "+this.publicName
+                + "\npubkey = " + Arrays.toString(publicKey);
+    }
+    
+    class HpkeSuite {
+        int kdfId, aeadId;
+        
+        HpkeSuite(int k, int a) {
+            this.kdfId = k;
+            this.aeadId = a;
+        }
+        
+        byte[] toSerial() {
+            byte[] answer = new byte[4];
+            answer[0] = (byte)(this.kdfId >> 8);
+            answer[1] = (byte)(this.kdfId);
+            answer[2] = (byte)(this.aeadId >> 8);
+            answer[3] = (byte)(this.aeadId);
+            return answer;
+        }
+    }
+
+}

--- a/src/java.base/share/classes/sun/security/ssl/EchExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/EchExtension.java
@@ -1,0 +1,102 @@
+package sun.security.ssl;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
+import sun.security.ssl.ClientHello.ClientHelloMessage;
+import sun.security.ssl.SSLExtension.ExtensionConsumer;
+import sun.security.ssl.SSLHandshake.HandshakeMessage;
+import sun.security.ssl.SSLExtension.SSLExtensionSpec;
+
+public class EchExtension {
+    static final HandshakeProducer chNetworkProducer =
+            new CHEchProducer();
+    static final ExtensionConsumer chOnLoadConsumer =
+            new CHEchConsumer();
+    static final HandshakeAbsence chOnLoadAbsence = null;
+    static final EchStringizer echStringizer =
+            new EchStringizer();
+
+    /**
+     * The "ech" extension.
+     */
+    static class EchSpec implements SSLExtensionSpec {
+
+        private EchSpec(HandshakeContext hc,
+                ByteBuffer m) throws IOException {
+        }
+
+        @Override
+        public String toString() {
+            return "<some ech client hello>";
+        }
+    }
+
+    private static final class EchStringizer implements SSLStringizer {
+        @Override
+        public String toString(HandshakeContext hc, ByteBuffer buffer) {
+            return "ECH Extension, buffer = " + Arrays.toString(buffer.array());
+        }
+    }
+
+    private static final
+            class CHEchProducer implements HandshakeProducer {
+        // Prevent instantiation of this class.
+        private CHEchProducer() {
+            // blank
+        }
+
+        @Override
+        public byte[] produce(ConnectionContext context,
+                HandshakeMessage message) throws IOException {
+            ClientHandshakeContext chc = (ClientHandshakeContext) context;
+
+            // Is it a supported and enabled extension?
+            if (!chc.sslConfig.isAvailable(SSLExtension.CH_ECH)) {
+                if (SSLLogger.isOn && SSLLogger.isOn("ssl,handshake")) {
+                    SSLLogger.fine(
+                            "Ignore unavailable ech extension");
+                }
+                return null;
+            }
+            SSLLogger.info("[EchExtension] chc = "+chc+", echconf = "+chc.echConfig);
+            if (chc.echConfig == null) {
+                SSLLogger.info("No ECHConfig found");
+                return null;
+            }
+            ECHConfig echConfig = chc.getEchConfig();
+            byte[] answer = echConfig.produceExtension(chc.isInnerEch());
+            if (!chc.innerEch) {
+                ClientHelloMessage outer = chc.initialClientHelloMsg;
+
+                HPKEContext hpkeContext = chc.hpkeContext;
+                byte[] epb = hpkeContext.getEphemeralPublicKeyBytes();
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                baos.write(answer);
+                baos.write(0);
+                baos.write(0x20);
+                baos.write(epb);
+                answer = baos.toByteArray();
+            }
+            return answer;
+        }
+    }
+
+    private static final
+            class CHEchConsumer implements ExtensionConsumer {
+        // Prevent instantiation of this class.
+        private CHEchConsumer() {
+            // blank
+        }
+
+        @Override
+        public void consume(ConnectionContext context,
+            HandshakeMessage message, ByteBuffer buffer) throws IOException {
+            // The consuming happens in server side only.
+            ServerHandshakeContext shc = (ServerHandshakeContext)context;
+        }
+    }
+
+}

--- a/src/java.base/share/classes/sun/security/ssl/HPKEContext.java
+++ b/src/java.base/share/classes/sun/security/ssl/HPKEContext.java
@@ -1,0 +1,271 @@
+package sun.security.ssl;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.security.GeneralSecurityException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.Key;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.SecureRandom;
+import java.security.interfaces.XECPrivateKey;
+import java.security.interfaces.XECPublicKey;
+import java.security.spec.KeySpec;
+import java.security.spec.NamedParameterSpec;
+import java.security.spec.XECPrivateKeySpec;
+import java.security.spec.XECPublicKeySpec;
+import java.util.*;
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.KeyAgreement;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import static sun.security.ssl.NamedGroup.X25519;
+
+public class HPKEContext {
+
+    private final KeyPair ephemeralKeyPair;
+    private final PublicKey remotePublicKey;
+    private final byte[] info;
+
+    private byte[] nonce;
+    private byte[] key;
+
+    /**
+     *
+     * @param pkR the PublicKey of the Remote peer
+     */
+    HPKEContext(PublicKey pkR, byte[] info) throws IOException {
+        this(pkR, deriveKeyPair(null), info);
+    }
+
+    HPKEContext(PublicKey pkR, KeyPair ephemeral, byte[] info) {
+        this.remotePublicKey = pkR;
+        this.ephemeralKeyPair = ephemeral;
+        this.info = info;
+    }
+
+    HPKEContext(byte[] nonce, byte[] key, byte[] info) {
+        this.nonce = nonce;
+        this.key = key;
+        this.info = info;
+        this.ephemeralKeyPair = null;
+        this.remotePublicKey = null;
+    }
+
+    void create() throws IOException {
+        byte[] sharedSecret = encapsulate(ephemeralKeyPair, remotePublicKey);
+        SSLLogger.info("SHAREDSECRET", sharedSecret);
+        do_middle(sharedSecret);
+    }
+
+    void do_middle(byte[] sharedSecret) throws IOException {
+        byte[] l1 = labeledExtract("".getBytes(), "psk_id_hash".getBytes(), SUITEID2, "".getBytes());
+        byte[] l2 = labeledExtract("".getBytes(), "info_hash".getBytes(), SUITEID2, info);
+        byte[] key_schedule_context = new byte[l1.length + l2.length + 1];
+        key_schedule_context[0] = 0;
+        System.arraycopy(l1, 0, key_schedule_context, 1, l1.length);
+        System.arraycopy(l2, 0, key_schedule_context, l1.length + 1, l2.length);
+
+        byte[] secret = labeledExtract(sharedSecret, "secret".getBytes(), SUITEID2, "".getBytes());
+        byte[] mykey = labeledExpand(secret, "key".getBytes(), key_schedule_context, SUITEID2, 16);
+        byte[] base_nonce = labeledExpand(secret, "base_nonce".getBytes(), key_schedule_context, SUITEID2, 12);
+
+        byte[] exporter_secret = labeledExpand(secret, "exp".getBytes(), key_schedule_context, SUITEID2, 32);
+        this.key = mykey;
+        this.nonce = base_nonce;
+    }
+
+    // dhkem_extract_and_expand
+    private byte[] encapsulate(KeyPair ephemeralPair, PublicKey remotePk) throws IOException {
+        try {
+            PrivateKey sk = ephemeralPair.getPrivate();
+            PublicKey pkEm = ephemeralPair.getPublic();
+            NamedGroup ng = NamedGroup.X25519;
+            KeyAgreement ka = KeyAgreement.getInstance(ng.algorithm);
+            ka.init(sk);
+            Key sharedKey = ka.doPhase(remotePk, true);
+            byte[] dh = ka.generateSecret();
+            byte[] kemContext = new byte[64];
+            System.arraycopy(pkEm.getEncoded(), 12, kemContext, 0, 32);
+            System.arraycopy(remotePk.getEncoded(), 12, kemContext, 32, 32);
+            byte[] sharedSecret = extractAndExpand(dh, kemContext);
+            return sharedSecret;
+        } catch (NoSuchAlgorithmException | InvalidKeyException ex) {
+            throw new IOException(ex);
+        }
+    }
+
+    byte[] seal(byte[] aad, byte[] pt) throws IOException {
+        try {
+            // we assume aeadId = 0x0001 which is AES-GCM-128
+            final Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+            byte[] iv = this.nonce;
+            GCMParameterSpec parameterSpec = new GCMParameterSpec(128, iv); //128 bit auth tag length
+            
+            SecretKey secretKey = new SecretKeySpec(key, "AES");
+            cipher.init(Cipher.ENCRYPT_MODE, secretKey, parameterSpec);
+            cipher.updateAAD(aad);
+            byte[] fin = cipher.doFinal(pt);
+            SSLLogger.info("Cipher", fin);
+            return fin;
+        } catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeyException | InvalidAlgorithmParameterException | IllegalBlockSizeException | BadPaddingException ex) {
+            throw new IOException (ex);
+        }
+    }
+
+    public PublicKey getEphemeralPublicKey() {
+        return ephemeralKeyPair.getPublic();
+    }
+
+    public byte[] getEphemeralPublicKeyBytes() {
+        byte[] answer = new byte[32];
+        System.arraycopy(getEphemeralPublicKey().getEncoded(), 12, answer, 0, 32);
+        return answer;
+    }
+
+    /**
+     * Convert the encoded bytes from an X25519 public key into a public key.
+     * See HKDF for a similar operation
+     *
+     * @param uBytes
+     * @return a public key
+     * @throws IOException whenever something goes wrong.
+     */
+    static PublicKey convertEncodedPublicKey(byte[] uBytes) throws IOException {
+        try {
+            NamedGroup ng = NamedGroup.X25519;
+            Utilities.reverseBytes(uBytes);
+            BigInteger u = new BigInteger(1, uBytes);
+            XECPublicKeySpec xecPublicKeySpec = new XECPublicKeySpec(
+                    new NamedParameterSpec(ng.name), u);
+            KeyFactory factory = KeyFactory.getInstance(ng.algorithm);
+            XECPublicKey publicKey = (XECPublicKey) factory.generatePublic(
+                    xecPublicKeySpec);
+            return publicKey;
+        } catch (Exception e) {
+            throw new IOException(e);
+        }
+    }
+
+    public static KeyPair deriveKeyPair(byte[] ikm) throws IOException {
+        try {
+            if (ikm == null) {
+                ikm = new byte[32];
+                new Random().nextBytes(ikm);
+            }
+            HKDF hkdf = new HKDF("SHA256");
+            SecretKeySpec salt = null;
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            baos.writeBytes("HPKE-v1".getBytes());
+            baos.writeBytes(SUITEID);
+            baos.writeBytes("dkp_prk".getBytes());
+            baos.writeBytes(ikm);
+            byte[] fullikm = baos.toByteArray();
+            SecretKeySpec inputKey = new SecretKeySpec(fullikm, "HKDF-IMK");
+            SecretKey extract = hkdf.extract(salt, inputKey, "dpk_prk");
+            ByteArrayOutputStream baos2 = new ByteArrayOutputStream();
+            baos2.writeBytes(new byte[]{0x0, 0x20});
+            baos2.writeBytes("HPKE-v1".getBytes());
+            baos2.writeBytes(SUITEID);
+            baos2.writeBytes("sk".getBytes());
+            byte[] ikm2 = baos2.toByteArray();
+            SecretKey expand = hkdf.expand(extract, ikm2, 32, "HKDF");
+            byte[] eencoded = expand.getEncoded();
+
+            NamedParameterSpec paramSpec = new NamedParameterSpec("X25519");
+            KeyFactory kf = KeyFactory.getInstance("XDH");
+            KeySpec privateSpec = new XECPrivateKeySpec(paramSpec, eencoded);
+
+            PrivateKey myPrivateKey = kf.generatePrivate(privateSpec);
+            PublicKey myPublicKey = generatePublicKeyFromPrivate((XECPrivateKey) myPrivateKey);
+            KeyPair keypair = new KeyPair(myPublicKey, myPrivateKey);
+            return keypair;
+        } catch (Exception ex) {
+            throw new IOException(ex);
+        }
+    }
+
+    static byte[] labeledExtract(byte[] salt, byte[] label, byte[] suite_id, byte[] ikm) {
+        try {
+            byte[] labeled_ikm = concat("HPKE-v1".getBytes(), concat(suite_id, concat(label, ikm)));
+            HKDF hkdf = new HKDF("SHA256");
+            SecretKeySpec inputKey = new SecretKeySpec(labeled_ikm, "HKDF-IMK");
+            SecretKeySpec saltks = null;
+            if (salt.length > 0) {
+                saltks = new SecretKeySpec(salt, "HmacSHA256");
+            }
+            return hkdf.extract(saltks, inputKey, "hkdf").getEncoded();
+        } catch (NoSuchAlgorithmException ex) {
+            ex.printStackTrace();
+        } catch (InvalidKeyException ex) {
+            ex.printStackTrace();
+        }
+        return null;
+    }
+
+    static byte[] labeledExpand(byte[] prk, byte[] label, byte[] info, byte[] suite_id, int l) throws IOException {
+        try {
+            byte hi = (byte) (l / 256);
+            byte lo = (byte) (l % 256);
+            byte[] labeled_info = concat(new byte[]{hi, lo}, concat("HPKE-v1".getBytes(), concat(suite_id, concat(label, info))));
+            HKDF hkdf = new HKDF("SHA256");
+            return hkdf.expand(new SecretKeySpec(prk, "HmacSHA256"), labeled_info, l, "HPKE").getEncoded();
+        } catch (Exception ex) {
+            throw new IOException(ex);
+        }
+    }
+
+    private static byte[] concat(byte[] a, byte[] b) {
+        int al = a.length;
+        int bl = b.length;
+        byte[] c = new byte[al + bl];
+        System.arraycopy(a, 0, c, 0, al);
+        System.arraycopy(b, 0, c, al, bl);
+        return c;
+    }
+
+    static PublicKey generatePublicKeyFromPrivate(XECPrivateKey privateKey) throws GeneralSecurityException {
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance(X25519.name);
+        keyPairGenerator.initialize(new NamedParameterSpec(X25519.name), new StaticSecureRandom(privateKey.getScalar().get()));
+        return keyPairGenerator.generateKeyPair().getPublic();
+    }
+    
+    static byte[] extractAndExpand(byte[] dh, byte[] kemctx) throws IOException {
+        int Nsecret = 32; 
+        byte[] eae_prk = labeledExtract("".getBytes(), "eae_prk".getBytes(), SUITEID, dh);
+        byte[] shared_secret = labeledExpand(eae_prk, "shared_secret".getBytes(),
+                kemctx,SUITEID, Nsecret);
+        return shared_secret;
+    }
+
+    public static class StaticSecureRandom extends SecureRandom {
+
+        private static final long serialVersionUID = 1234567L;
+
+        private final byte[] privateKey;
+
+        public StaticSecureRandom(byte[] privateKey) {
+            this.privateKey = privateKey.clone();
+        }
+
+        @Override
+        public void nextBytes(byte[] bytes) {
+            System.arraycopy(privateKey, 0, bytes, 0, privateKey.length);
+        }
+
+    }
+
+    private static final byte[] SUITEID = new byte[]{0x4b, 0x45, 0x4d, 0x0, 0x20}; //KEM0x0020
+    private static final byte[] SUITEID2 = new byte[]{0x48, 0x50, 0x4B, 0x45, 0x0, 0x20, 0x0, 0x1, 0x0, 0x1}; //HPKE[kemid,kdfid,aeadid]
+
+}

--- a/src/java.base/share/classes/sun/security/ssl/HandshakeContext.java
+++ b/src/java.base/share/classes/sun/security/ssl/HandshakeContext.java
@@ -78,6 +78,8 @@ abstract class HandshakeContext implements ConnectionContext {
     final SSLContextImpl                    sslContext;
     final TransportContext                  conContext;
     final SSLConfiguration                  sslConfig;
+    ECHConfig                               echConfig;
+    HPKEContext                             hpkeContext;
 
     // consolidated parameters
     final List<ProtocolVersion>             activeProtocols;
@@ -124,6 +126,8 @@ abstract class HandshakeContext implements ConnectionContext {
     RandomCookie                            clientHelloRandom;
     RandomCookie                            serverHelloRandom;
     byte[]                                  certRequestContext;
+    byte[] innerClientHello; // if ECH is used
+    RandomCookie innerClientHelloRandom;
 
     ////////////////////
     // Extensions
@@ -157,17 +161,22 @@ abstract class HandshakeContext implements ConnectionContext {
 
     // OCSP Stapling info
     boolean                                 staplingActive = false;
+    boolean innerEch;
+
 
     protected HandshakeContext(SSLContextImpl sslContext,
             TransportContext conContext) throws IOException {
         this.sslContext = sslContext;
         this.conContext = conContext;
         this.sslConfig = (SSLConfiguration)conContext.sslConfig.clone();
-
         this.algorithmConstraints = SSLAlgorithmConstraints.wrap(
                 sslConfig.userSpecifiedAlgorithmConstraints);
-        this.activeProtocols = getActiveProtocols(sslConfig.enabledProtocols,
-                sslConfig.enabledCipherSuites, algorithmConstraints);
+        if ((sslConfig.echConfig != null) && (!sslConfig.echConfig.isEmpty())) {
+            this.activeProtocols = List.of(ProtocolVersion.TLS13);
+        } else {
+            this.activeProtocols = getActiveProtocols(sslConfig.enabledProtocols,
+                    sslConfig.enabledCipherSuites, algorithmConstraints);
+        }
         if (activeProtocols.isEmpty()) {
             throw new SSLHandshakeException(
                 "No appropriate protocol (protocol is disabled or " +
@@ -353,6 +362,22 @@ abstract class HandshakeContext implements ConnectionContext {
         }
 
         return Collections.unmodifiableList(suites);
+    }
+
+    void setInnerEch(boolean v) {
+        this.innerEch = v;
+    }
+
+    boolean isInnerEch() {
+        return innerEch;
+    }
+
+    void setEchConfig(ECHConfig ec) {
+        this.echConfig = ec;
+    }
+
+    ECHConfig getEchConfig() {
+        return this.echConfig;
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/ssl/KeyShareExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/KeyShareExtension.java
@@ -289,6 +289,10 @@ final class KeyShareExtension {
 
         private static byte[] getShare(ClientHandshakeContext chc,
                 NamedGroup ng) {
+            if (chc.innerEch) {
+                SSLPossession existing = chc.handshakePossessions.get(0);
+                return existing.encode();
+            }
             SSLKeyExchange ke = SSLKeyExchange.valueOf(ng);
             if (ke == null) {
                 if (SSLLogger.isOn && SSLLogger.isOn("ssl,handshake")) {

--- a/src/java.base/share/classes/sun/security/ssl/SSLConfiguration.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLConfiguration.java
@@ -71,6 +71,10 @@ final class SSLConfiguration implements Cloneable {
     boolean                     isClientMode;
     boolean                     enableSessionCreation;
 
+    // ECH Config
+    String innerSNI;
+    String echConfig;
+
     // the application layer protocol negotiation configuration
     BiFunction<SSLSocket, List<String>, String> socketAPSelector;
     BiFunction<SSLEngine, List<String>, String> engineAPSelector;
@@ -209,6 +213,12 @@ final class SSLConfiguration implements Cloneable {
     }
 
     void setSSLParameters(SSLParameters params) {
+        if (params.getInnerSNI() != null) {
+            this.innerSNI = params.getInnerSNI();
+        }
+        if (params.getEchConfig() != null) {
+            this.echConfig = params.getEchConfig();
+        }
         AlgorithmConstraints ac = params.getAlgorithmConstraints();
         if (ac != null) {
             this.userSpecifiedAlgorithmConstraints = ac;

--- a/src/java.base/share/classes/sun/security/ssl/SSLExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLExtension.java
@@ -496,7 +496,15 @@ enum SSLExtension implements SSLStringizer {
                                 PreSharedKeyExtension.shOnLoadConsumer,
                                 PreSharedKeyExtension.shOnLoadAbsence,
                                 null, null,
-                                PreSharedKeyExtension.shStringizer);
+                                PreSharedKeyExtension.shStringizer),
+    CH_ECH                 (0xfe0d, "encrypted_client_hello",
+                                SSLHandshake.CLIENT_HELLO,
+                                ProtocolVersion.PROTOCOLS_OF_13,
+                                EchExtension.chNetworkProducer,
+                                EchExtension.chOnLoadConsumer,
+                                EchExtension.chOnLoadAbsence,
+                                null, null,
+                                EchExtension.echStringizer);
 
     final int id;
     final SSLHandshake handshakeType;

--- a/src/java.base/share/classes/sun/security/ssl/ServerHello.java
+++ b/src/java.base/share/classes/sun/security/ssl/ServerHello.java
@@ -30,6 +30,9 @@ import java.nio.ByteBuffer;
 import java.security.AlgorithmConstraints;
 import java.security.CryptoPrimitive;
 import java.security.GeneralSecurityException;
+import java.security.InvalidKeyException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.EnumSet;
@@ -40,6 +43,7 @@ import java.util.Locale;
 import java.util.Map;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLProtocolException;
@@ -869,7 +873,43 @@ final class ServerHello {
         public void consume(ConnectionContext context,
                 ByteBuffer message) throws IOException {
             // The consuming happens in client side only.
-            ClientHandshakeContext chc = (ClientHandshakeContext)context;
+            ClientHandshakeContext chc = (ClientHandshakeContext) context;
+
+            if (chc.echConfig != null) {
+
+                byte[] chBytes0 = chc.innerClientHello;
+                int csize = chBytes0.length;
+                byte[] chBytes = new byte[csize + 4];
+                chBytes[0] = 0x01;
+                chBytes[1] = (byte) (csize >> 16);
+                chBytes[2] = (byte) (csize >> 8);
+                chBytes[3] = (byte) (csize);
+                System.arraycopy(chBytes0, 0, chBytes, 4, csize);
+                ByteBuffer dup = message.duplicate();
+                int size = dup.remaining();
+                byte[] shBytes = new byte[size + 4];
+                shBytes[0] = 0x02;
+                shBytes[1] = (byte) (size >> 16);
+                shBytes[2] = (byte) (size >> 8);
+                shBytes[3] = (byte) (size);
+                dup.get(shBytes, 4, size);
+                boolean echOK = checkAcceptConfirmation(chBytes, shBytes);
+                SSLLogger.info("ServerHello accepted us? " + echOK);
+                if (echOK) {
+                    byte[] last = chc.handshakeHash.removeLastReceived();
+                    chc.handshakeHash.finish();
+                    chc.clientHelloRandom = chc.innerClientHelloRandom;
+                    chc.initialClientHelloMsg = chc.innerClientHelloMessage;
+
+                    HandshakeOutStream myhos = new HandshakeOutStream(null);
+                    myhos.write(chc.innerClientHelloMessage.handshakeType().id);
+                    myhos.putInt24(chc.innerClientHelloMessage.messageLength());
+
+                    chc.innerClientHelloMessage.send(myhos);
+                    chc.handshakeHash.receive(myhos.toByteArray());
+                    chc.handshakeHash.receive(last);
+                }
+            }
 
             // clean up this consumer
             chc.handshakeConsumers.remove(SSLHandshake.SERVER_HELLO.id);
@@ -1013,6 +1053,61 @@ final class ServerHello {
                 }
             }
         }
+            boolean checkAcceptConfirmation(byte[] chBytes, byte[] shBytes) throws IOException {
+            try {
+                SSLLogger.info("Check accept, clientHello = ", chBytes);
+                SSLLogger.info("Check accept, serverHello = ", shBytes);
+ // create tbuf
+                int chLen = chBytes.length;
+                int shLen = shBytes.length;
+                byte[] tbuf = new byte[chLen + shLen];
+                System.arraycopy(chBytes, 0, tbuf, 0, chLen);
+                System.arraycopy(shBytes, 0, tbuf, chLen, shLen);
+                // add zeros over last 8 bytes of serverHello.Random
+                int shoffset = 6 + 24;
+                for (int i = 0; i < 8; i++) {
+                    tbuf[chLen + shoffset + i] = 0;
+                }
+                // calculate message digest
+                MessageDigest md = MessageDigest.getInstance("SHA-384");
+                byte[] data = md.digest(tbuf);
+
+                // extract based on client.random bytes
+                byte[] rndBytes = new byte[32];
+                System.arraycopy(chBytes, 6, rndBytes, 0, 32);
+                SecretKey inputKey = new SecretKeySpec(rndBytes, "KDF-PRK");
+                byte[] salt = new byte[48];
+                HKDF hkdfExtract = new HKDF("SHA-384");
+                SecretKey extract = hkdfExtract.extract(salt, inputKey, "KDF-OKM");
+                byte[] secret = extract.getEncoded();
+
+                // expand
+                byte[] label = "ech accept confirmation".getBytes();
+
+                HKDF hkdf = new HKDF("SHA-384");
+                byte[] prefixLabel = "tls13 ".getBytes();
+                byte[] realLabel = new byte[4 + prefixLabel.length + label.length + data.length];
+                realLabel[0] = 0;
+                realLabel[1] = 8;
+                realLabel[2] = (byte) (label.length + prefixLabel.length);
+                System.arraycopy(prefixLabel, 0, realLabel, 3, prefixLabel.length);
+                System.arraycopy(label, 0, realLabel, 3 + prefixLabel.length, label.length);
+                int idx = 3 + label.length + prefixLabel.length;
+                realLabel[idx] = (byte) data.length;
+                idx++;
+                System.arraycopy(data, 0, realLabel, idx, data.length);
+                SecretKey prk = new SecretKeySpec(secret, "prk");
+                SecretKey res = hkdf.expand(prk, realLabel, 8, "SHA2-384");
+
+                byte[] expected = new byte[8];
+                System.arraycopy(shBytes, 30, expected, 0, 8);
+                boolean works = Arrays.equals(expected, res.getEncoded());
+                return works;
+            } catch (NoSuchAlgorithmException | InvalidKeyException ex) {
+                throw new IOException(ex);
+            }
+        }
+
     }
 
     private static final

--- a/src/java.base/share/classes/sun/security/ssl/ServerNameExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/ServerNameExtension.java
@@ -224,12 +224,22 @@ final class ServerNameExtension {
 
             // Produce the extension.
             List<SNIServerName> serverNames;
-            if (chc.isResumption && (chc.resumingSession != null)) {
+            String ehidden = chc.innerSNI;
+            if (chc.isResumption && (chc.resumingSession != null) && (ehidden == null)) {
                 serverNames =
                         chc.resumingSession.getRequestedServerNames();
             } else {
-                serverNames = chc.sslConfig.serverNames;
-            }   // Shall we use host too?
+                if (ehidden == null) {
+                    serverNames = chc.sslConfig.serverNames;
+                } else {
+                    if (chc.isInnerEch()) {
+                        serverNames = List.of(new SNIHostName(ehidden));
+                    } else {
+                        String hname = chc.getEchConfig().getPublicName();
+                        serverNames = List.of(new SNIHostName(hname));
+                    }
+                }
+            }
 
             // Empty server name list is not allowed in client mode.
             if ((serverNames != null) && !serverNames.isEmpty()) {

--- a/src/java.net.http/share/classes/jdk/internal/net/http/AsyncSSLConnection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/AsyncSSLConnection.java
@@ -45,8 +45,13 @@ class AsyncSSLConnection extends AbstractAsyncSSLConnection {
     AsyncSSLConnection(InetSocketAddress addr,
                        HttpClientImpl client,
                        String[] alpn) {
-        super(addr, client, Utils.getServerName(addr), addr.getPort(), alpn);
-        plainConnection = new PlainHttpConnection(addr, client);
+        this (addr, client, alpn, null);
+    }
+            AsyncSSLConnection(InetSocketAddress addr,
+                       HttpClientImpl client,
+                       String[] alpn, HttpRequestImpl request) {
+        super(addr, client, Utils.getServerName(addr), addr.getPort(), alpn, request);
+        plainConnection = new PlainHttpConnection(addr, client, request);
         writePublisher = new PlainHttpPublisher();
     }
 

--- a/src/java.net.http/share/classes/jdk/internal/net/http/HttpConnection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/HttpConnection.java
@@ -79,7 +79,15 @@ abstract class HttpConnection implements Closeable {
     private final long id;
 
     HttpConnection(InetSocketAddress address, HttpClientImpl client) {
-        this.address = address;
+        this (address, client, null);
+    }
+    HttpConnection(InetSocketAddress address, HttpClientImpl client, HttpRequestImpl req) {
+        if ((req != null) && (req.headers().firstValue("outerSNI").isPresent())){
+            String h = req.headers().firstValue("outerSNI").get();
+            this.address = new InetSocketAddress(h, address.getPort());
+        } else {
+            this.address = address;
+        }
         this.client = client;
         trailingOperations = new TrailingOperations();
         this.id = newConnectionId(client);
@@ -303,7 +311,7 @@ abstract class HttpConnection implements Closeable {
             return new AsyncSSLTunnelConnection(addr, client, alpn, proxy,
                                                 proxyTunnelHeaders(request));
         else
-            return new AsyncSSLConnection(addr, client, alpn);
+            return new AsyncSSLConnection(addr, client, alpn, request);
     }
 
     /**

--- a/src/java.net.http/share/classes/jdk/internal/net/http/PlainHttpConnection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/PlainHttpConnection.java
@@ -293,7 +293,11 @@ class PlainHttpConnection extends HttpConnection {
     }
 
     PlainHttpConnection(InetSocketAddress addr, HttpClientImpl client) {
-        super(addr, client);
+        this (addr, client, null);
+    }
+
+    PlainHttpConnection(InetSocketAddress addr, HttpClientImpl client, HttpRequestImpl request) {
+        super(addr, client, request);
         try {
             this.chan = SocketChannel.open();
             chan.configureBlocking(false);


### PR DESCRIPTION
This PR adds support for ECH in the TLS 1.3 handshake.
The network code now checks for "innerSNI", "outerSNI" and "echConfig" in the request headers of a HTTP request.
If those are not present, nothing in the flow should change.